### PR TITLE
Add Resend Email API Integration + Related Fixes

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -2,3 +2,5 @@ MYSQL_HOST="mysql:host=localhost;dbname=Your_Database_Name_here"
 MYSQL_USERNAME="Replace_Me"
 MYSQL_PASSWORD=""
 
+RESEND_API_KEY="re_your_api_key_here"
+RESEND_FROM_EMAIL="onboarding@resend.dev"

--- a/.env_example
+++ b/.env_example
@@ -1,4 +1,4 @@
 MYSQL_HOST="mysql:host=localhost;dbname=Your_Database_Name_here"
 MYSQL_USERNAME="Replace_Me"
 MYSQL_PASSWORD=""
-SENDGRID_API_KEY=""
+

--- a/.env_example
+++ b/.env_example
@@ -1,6 +1,6 @@
 MYSQL_HOST="mysql:host=localhost;dbname=Your_Database_Name_here"
 MYSQL_USERNAME="Replace_Me"
 MYSQL_PASSWORD=""
-
+APP_URL="http://localhost:9001"
 RESEND_API_KEY="re_your_api_key_here"
-RESEND_FROM_EMAIL="onboarding@resend.dev"
+RESEND_FROM_EMAIL="yourinfo@verifiedDomain.com"

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 /src/images/*
 !/src/images/coming-soon.jpg
 .env
+.env.local

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "ext-curl": "*",
     "vlucas/phpdotenv": "^5.6",
     "phpmailer/phpmailer": "^6.9",
-    "sendgrid/sendgrid": "~7"
+    "resend/resend-php": "1.2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9"

--- a/cron_job_email.php
+++ b/cron_job_email.php
@@ -1,6 +1,7 @@
 <?php
 require 'vendor/autoload.php';
-$dotenv = Dotenv\Dotenv::createImmutable( __DIR__);
+$envFile = file_exists(__DIR__ . '/../.env.local') ? '.env.local' : '.env';
+$dotenv = Dotenv\Dotenv::createImmutable( __DIR__ . "/..", $envFile);
 $dotenv->load();
 use App\Classes\Database;
 

--- a/cron_job_email.php
+++ b/cron_job_email.php
@@ -9,6 +9,7 @@ $email_info = new \App\Classes\Cart();
 $email_object = new \App\Classes\Email;
 $pass_object = new \App\Classes\Password();
 
+
 if (PHP_SAPI !== 'cli') {
     exit("ACCESS DENIED");
 }
@@ -19,10 +20,12 @@ $email_chunks = $query->CustomSQL('SELECT order_id, user_id FROM order_complete 
 $password_chunks = $query->CustomSQL('SELECT email, token FROM password_resets WHERE password_sent = 0');
 
 
+// If no email chunks or password chunks, exit
 if (!$email_chunks && !$password_chunks) {
    exit();
 }
 
+// Email sends email and updates order_complete table indicating cron job has run
 if ($email_chunks) {
     foreach ($email_chunks as $chunk) {
         $params = [
@@ -47,11 +50,13 @@ if ($email_chunks) {
     }
 }
 
+// Password Reset sends email and updates password_resets table indicating cron job has run
 if ($password_chunks) {
     foreach ($password_chunks as $chunk) {
         $email = $chunk['email'];
         $token = $chunk['token'];
 
+        //replace with sendSMTP for localhost testing
         $mail_sent = $pass_object->sendPassword($email, $token);
 
         if ($mail_sent) {

--- a/cron_job_email.php
+++ b/cron_job_email.php
@@ -1,7 +1,7 @@
 <?php
 require 'vendor/autoload.php';
-$envFile = file_exists(__DIR__ . '/../.env.local') ? '.env.local' : '.env';
-$dotenv = Dotenv\Dotenv::createImmutable( __DIR__ . "/..", $envFile);
+$envFile = file_exists(__DIR__ . '/.env.local') ? '.env.local' : '.env';
+$dotenv = Dotenv\Dotenv::createImmutable( __DIR__, $envFile);
 $dotenv->load();
 use App\Classes\Database;
 

--- a/includes/header.php
+++ b/includes/header.php
@@ -2,7 +2,9 @@
 session_start();
 set_include_path( get_include_path() . PATH_SEPARATOR . $_SERVER['DOCUMENT_ROOT'] );
 require 'vendor/autoload.php';
-$dotenv = Dotenv\Dotenv::createImmutable( __DIR__ . "/..");
+
+$envFile = file_exists(__DIR__ . '/../.env.local') ? '.env.local' : '.env';
+$dotenv = Dotenv\Dotenv::createImmutable( __DIR__ . "/..", $envFile);
 $dotenv->load();
 date_default_timezone_set('America/Chicago');
 

--- a/includes/nav.php
+++ b/includes/nav.php
@@ -32,7 +32,7 @@
                             <li><a class="nav-link" href="/src/forms/vue_groceries_form.php">Vue Groceries</a></li>
                             <li><a class="nav-link" href="/random_meal.php">Hungry?</a></li>
                             <li><hr class="dropdown-divider"></hr></li>
-                            <li><a class="nav-link" href="/logout.php">Logout</a></li>
+                            <li><a class="nav-link" href="/logout.php">Log Out</a></li>
                         </ul>
                     </div>
                     <li>
@@ -40,7 +40,7 @@
                     </li>
                 <?php else : ?>
                     <li class="nav-item">
-                        <a class="nav-link" href="/login.php">Login</a>
+                        <a class="nav-link" href="/login.php">Log In</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="/register.php">Register</a>

--- a/includes/nav.php
+++ b/includes/nav.php
@@ -28,10 +28,10 @@
                         </button>
                         <ul class="dropdown-menu">
                             <li><a class="nav-link" href="/cart.php">Shopping Cart</a></li>
-                            <li><hr class="dropdown-divider"></hr></li>
+                            <li><hr class="dropdown-divider"></li>
                             <li><a class="nav-link" href="/src/forms/vue_groceries_form.php">Vue Groceries</a></li>
                             <li><a class="nav-link" href="/random_meal.php">Hungry?</a></li>
-                            <li><hr class="dropdown-divider"></hr></li>
+                            <li><hr class="dropdown-divider"></li>
                             <li><a class="nav-link" href="/logout.php">Log Out</a></li>
                         </ul>
                     </div>

--- a/login.php
+++ b/login.php
@@ -13,7 +13,7 @@ if($_POST) {
         $errors[] = 'Invalid email';
     }
 
-    if (empty($email)) {
+    if (empty($password)) {
         $errors[] = 'Invalid password';
     }
 

--- a/new_pass_logic.php
+++ b/new_pass_logic.php
@@ -53,6 +53,6 @@ if (isset($_POST['new_password'])) {
 }
 //assign token here if user has not yet clicked new_password
 $token = $_GET['token'] ?? '';
-$token = sanitize($_GET['token']);
+$token = sanitize($token);
 
 include 'src/forms/new_pass_form.php';

--- a/src/Classes/Email.php
+++ b/src/Classes/Email.php
@@ -2,7 +2,8 @@
 
 namespace App\Classes;
 
-use Exception;
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception;
 
 class Email
 {

--- a/src/Classes/Email.php
+++ b/src/Classes/Email.php
@@ -4,9 +4,11 @@ namespace App\Classes;
 
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
+use Resend;
 
 class Email
 {
+    // Sends email using SMTP for localhost testing
     private function sendSMTP($to, $subject, $html)
     {
         $mail = new PHPMailer(true);
@@ -33,7 +35,27 @@ class Email
             return false;
         }
     }
-    public function sendEmail($email_items, $order_details, $email)
+
+    // Sends email using Resend
+    private function sendResend($to, $subject, $html): bool
+    {
+        try {
+            $resend = Resend::client($_ENV['RESEND_API_KEY']);
+            
+            $result = $resend->emails->send([
+                'from' => $_ENV['RESEND_FROM_EMAIL'],
+                'to' => $to,
+                'subject' => $subject,
+                'html' => $html,
+            ]);
+
+            return isset($result['id']);
+        } catch (Exception $e) {
+            error_log("Resend Error: {$e->getMessage()}");
+            return false;
+        }
+    }
+    public function sendEmail($email_items, $order_details, $email): bool
     {
         $user_email = $email;
 
@@ -47,6 +69,7 @@ class Email
 
         $subject = "Receipt From Raywebdev.com";
 
-        return $this->sendSMTP($user_email, $subject, $msg);
+        //replace with sendSMTP for localhost testing
+        return $this->sendResend($user_email, $subject, $msg);
     }
 }

--- a/src/Classes/Email.php
+++ b/src/Classes/Email.php
@@ -39,7 +39,7 @@ class Email
 
         ob_start();
         // Hard path to this file for raywebdev.com
-        include '/var/www/html/src/forms/email_items_form.php';
+        include __DIR__ . '/../forms/email_items_form.php';
         $msg = ob_get_contents();
         ob_end_clean();
 

--- a/src/Classes/Password.php
+++ b/src/Classes/Password.php
@@ -94,7 +94,8 @@ class Password
         ];
         $query->CustomSQL('UPDATE password_resets SET expired_token = :expired_token WHERE token = :token', $params);
 
-        return "Password reset, you can <a href='login.php'>login</a> now";
+        return "Password reset, you can <a href='{$_ENV['APP_URL']}/login.php'>login</a> now";
+
     }
 
     // Sends password reset email

--- a/src/Classes/Password.php
+++ b/src/Classes/Password.php
@@ -4,9 +4,11 @@ namespace App\Classes;
 
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
+use Resend;
 
 class Password
 {
+    // Sends email using SMTP for localhost testing
     private function sendSMTP($to, $subject, $html)
     {
         $mail = new PHPMailer(true);
@@ -34,7 +36,28 @@ class Password
         }
     }
 
-    public function getEmail($params)
+    // Sends email using Resend
+    private function sendResend($to, $subject, $html): bool
+    {
+        try {
+            $resend = Resend::client($_ENV['RESEND_API_KEY']);
+            
+            $result = $resend->emails->send([
+                'from' => $_ENV['RESEND_FROM_EMAIL'],
+                'to' => $to,
+                'subject' => $subject,
+                'html' => $html,
+            ]);
+
+            return isset($result['id']);
+        } catch (Exception $e) {
+            error_log("Resend Error: {$e->getMessage()}");
+            return false;
+        }
+    }
+
+    // Returns email from password_resets table
+    public function getEmail($params): array
     {
         $query = new \App\Classes\Query();
         return $query->CustomSQL(
@@ -43,7 +66,8 @@ class Password
         );
     }
 
-    public function isTokenExpired($params)
+    // Returns token from password_resets table
+    public function isTokenExpired($params): array
     {
         $query = new \App\Classes\Query();
         return $query->CustomSQL(
@@ -52,7 +76,8 @@ class Password
         );
     }
 
-    public function updatePassword($password, $email, $token)
+    // Updates password and expired_token in password_resets table
+    public function updatePassword($password, $email, $token): string
     {
         $query = new \App\Classes\Query();
 
@@ -72,7 +97,8 @@ class Password
         return "Password reset, you can <a href='login.php'>login</a> now";
     }
 
-    public function sendPassword($email, $token)
+    // Sends password reset email
+    public function sendPassword($email, $token): bool
     {
         $reset_link = "https://www.raywebdev.com/new_pass_logic.php?token=" . $token;
 
@@ -82,10 +108,12 @@ class Password
 
         $subject = "Password Reset at Raywebdev.com";
 
-        return $this->sendSMTP($email, $subject, $msg);
+        //replace with sendSMTP for localhost testing
+        return $this->sendResend($email, $subject, $msg);
     }
 
-    public function pendingEmail()
+    // Redirects to enter_email.php if no email is provided
+    public function pendingEmail(): void
     {
         if (!$_GET['email']) {
             $_SESSION['failure'] = "What are you doing..";

--- a/src/Classes/Password.php
+++ b/src/Classes/Password.php
@@ -94,7 +94,7 @@ class Password
         ];
         $query->CustomSQL('UPDATE password_resets SET expired_token = :expired_token WHERE token = :token', $params);
 
-        return "Password reset, you can <a href='{$_ENV['APP_URL']}/login.php'>login</a> now";
+        return "Password reset, you can <a href='{$_ENV['APP_URL']}/login.php'>log in</a> now";
 
     }
 

--- a/src/Classes/Password.php
+++ b/src/Classes/Password.php
@@ -100,7 +100,8 @@ class Password
     // Sends password reset email
     public function sendPassword($email, $token): bool
     {
-        $reset_link = "https://www.raywebdev.com/new_pass_logic.php?token=" . $token;
+        //APP_URL uses .env.local first, then .env to route URL.
+        $reset_link = $_ENV['APP_URL'] . "/new_pass_logic.php?token=" . $token;
 
         $msg  = "Hi there,<br><br>";
         $msg .= "Click on this <a href=\"$reset_link\">link</a> to reset your password on raywebdev.com.<br><br>";

--- a/src/Classes/User.php
+++ b/src/Classes/User.php
@@ -7,7 +7,7 @@ class User
     private string $username = '';
     private string $email = '';
     private string $password = '';
-    private string $today = '';
+    private string $date = '';
     private int $user_role = 0;
 
     public function __construct() {}
@@ -25,7 +25,7 @@ class User
 
     public function getDate() : string
     {
-        return $this->today;
+        return $this->date;
     }
 
     public function setDate(string $date): void

--- a/src/Classes/User.php
+++ b/src/Classes/User.php
@@ -25,7 +25,7 @@ class User
 
     public function getDate() : string
     {
-        return $this->date;
+        return $this->today;
     }
 
     public function setDate(string $date): void

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -88,4 +88,11 @@ class UserTest extends TestCase
         $this->assertNotFalse($db_email);
         $this->assertEquals($email, $db_email['email']);
     }
+
+    public function testGetDate()
+    {
+        $this->User->setDate('2026-05-19');
+        $result = $this->User->getDate();
+        $this->assertEquals('2026-05-19', $result);
+    }
 }


### PR DESCRIPTION
**Summary**

This Pull Request introduces full integration of the Resend Email API into the project, replacing SendGrid API and enabling reliable password reset emails in both local and production environments.

During implementation, several related issues surfaced (environment handling, reset link generation, UI text consistency), and those were addressed as part of this branch to ensure the email system works end‑to‑end.

<hr>

**What’s Included**

**Resend API integration**

- Added Email class to handle sending emails through Resend

- Added API key loading via .env / .env.local

- Updated password reset flow to queue emails for cron processing

**Environment‑aware URL generation**

- Reset links now use APP_URL instead of hardcoded production URLs

- Ensures correct behavior on localhost vs production

**Cron job improvements**

- Cron script now loads the correct environment file

- Fixed path resolution issues that caused fatal errors

- Confirmed cron can send emails locally and in production

**Password reset flow cleanup**

- Improved token generation and validation

- Ensured reset link messaging is accurate and grammatically correct

- Updated success message to use “log in” (verb form)

**UI/UX fixes**

- Updated nav item from “Login” → “Log In”

- Removed redundant &lt;hr&gt; closing tag

- Minor text consistency improvements

Fixes #154 